### PR TITLE
Allow nesting self in schemas

### DIFF
--- a/flask_accepts/utils.py
+++ b/flask_accepts/utils.py
@@ -5,17 +5,33 @@ from marshmallow.schema import Schema, SchemaMeta
 import uuid
 
 
-def unpack_list(val, api, model_name: str = None):
+def unpack_list(val, api, model_name: str = None, operation: str = "dump"):
     model_name = model_name or get_default_model_name()
-    return fr.List(map_type(val.inner, api, model_name))
+    return fr.List(map_type(val.inner, api, model_name, operation))
 
 
-def unpack_nested(val, api, model_name: str = None):
+def unpack_nested(val, api, model_name: str = None, operation: str = "dump"):
+    if val.nested == "self":
+        return unpack_nested_self(val, api, model_name, operation)
+
     model_name = get_default_model_name(val.nested)
-    return fr.Nested(map_type(val.nested, api, model_name))
+    return fr.Nested(map_type(val.nested, api, model_name, operation))
 
 
-def for_swagger(schema, api, model_name: str = None, operation="dump"):
+def unpack_nested_self(val, api, model_name: str = None, operation: str = "dump"):
+    model_name = model_name or get_default_model_name(val.schema)
+    fields = {
+        k: map_type(v, api, model_name, operation)
+        for k, v in (vars(val.schema).get("fields").items())
+        if type(v) in type_map and _check_load_dump_only(v, operation)
+    }
+    if val.many:
+        return fr.List(fr.Nested(api.model(f"{model_name}-child", fields)))
+    else:
+        return fr.Nested(api.model(f"{model_name}-child", fields))
+
+
+def for_swagger(schema, api, model_name: str = None, operation: str = "dump"):
     """
     Convert a marshmallow schema to equivalent Flask-RESTplus model
 
@@ -35,7 +51,7 @@ def for_swagger(schema, api, model_name: str = None, operation="dump"):
     if isinstance(schema, SchemaMeta):
         schema = schema()
     fields = {
-        k: map_type(v, api, model_name)
+        k: map_type(v, api, model_name, operation)
         for k, v in (vars(schema).get("fields").items())
         if type(v) in type_map and _check_load_dump_only(v, operation)
     }
@@ -55,32 +71,38 @@ def _check_load_dump_only(field: ma.Field, operation: str) -> bool:
 
 
 type_map = {
-    ma.AwareDateTime: lambda val, api, model_name: fr.Raw(example=val.default),
-    ma.Bool: lambda val, api, model_name: fr.Boolean(example=val.default),
-    ma.Boolean: lambda val, api, model_name: fr.Boolean(example=val.default),
-    ma.Constant: lambda val, api, model_name: fr.Raw(example=val.default),
-    ma.Date: lambda val, api, model_name: fr.Date(example=val.default),
-    ma.DateTime: lambda val, api, model_name: fr.DateTime(example=val.default),
+    ma.AwareDateTime: lambda val, api, model_name, operation: fr.Raw(
+        example=val.default
+    ),
+    ma.Bool: lambda val, api, model_name, operation: fr.Boolean(example=val.default),
+    ma.Boolean: lambda val, api, model_name, operation: fr.Boolean(example=val.default),
+    ma.Constant: lambda val, api, model_name, operation: fr.Raw(example=val.default),
+    ma.Date: lambda val, api, model_name, operation: fr.Date(example=val.default),
+    ma.DateTime: lambda val, api, model_name, operation: fr.DateTime(
+        example=val.default
+    ),
     # For some reason, fr.Decimal has no example parameter, so use Float instead
-    ma.Decimal: lambda val, api, model_name: fr.Float(example=val.default),
-    ma.Dict: lambda val, api, model_name: fr.Raw(example=val.default),
-    ma.Email: lambda val, api, model_name: fr.String(example=val.default),
-    ma.Float: lambda val, api, model_name: fr.Float(example=val.default),
-    ma.Function: lambda val, api, model_name: fr.Raw(example=val.default),
-    ma.Int: lambda val, api, model_name: fr.Integer(example=val.default),
-    ma.Integer: lambda val, api, model_name: fr.Integer(example=val.default),
-    ma.Length: lambda val, api, model_name: fr.Float(example=val.default),
-    ma.Mapping: lambda val, api, model_name: fr.Raw(example=val.default),
-    ma.NaiveDateTime: lambda val, api, model_name: fr.DateTime(example=val.default),
-    ma.Number: lambda val, api, model_name: fr.Float(example=val.default),
-    ma.Pluck: lambda val, api, model_name: fr.Raw(example=val.default),
-    ma.Raw: lambda val, api, model_name: fr.Raw(example=val.default),
-    ma.Str: lambda val, api, model_name: fr.String(example=val.default),
-    ma.String: lambda val, api, model_name: fr.String(example=val.default),
-    ma.Time: lambda val, api, model_name: fr.DateTime(example=val.default),
-    ma.Url: lambda val, api, model_name: fr.Url(example=val.default),
-    ma.URL: lambda val, api, model_name: fr.Url(example=val.default),
-    ma.UUID: lambda val, api, model_name: fr.String(example=val.default),
+    ma.Decimal: lambda val, api, model_name, operation: fr.Float(example=val.default),
+    ma.Dict: lambda val, api, model_name, operation: fr.Raw(example=val.default),
+    ma.Email: lambda val, api, model_name, operation: fr.String(example=val.default),
+    ma.Float: lambda val, api, model_name, operation: fr.Float(example=val.default),
+    ma.Function: lambda val, api, model_name, operation: fr.Raw(example=val.default),
+    ma.Int: lambda val, api, model_name, operation: fr.Integer(example=val.default),
+    ma.Integer: lambda val, api, model_name, operation: fr.Integer(example=val.default),
+    ma.Length: lambda val, api, model_name, operation: fr.Float(example=val.default),
+    ma.Mapping: lambda val, api, model_name, operation: fr.Raw(example=val.default),
+    ma.NaiveDateTime: lambda val, api, model_name, operation: fr.DateTime(
+        example=val.default
+    ),
+    ma.Number: lambda val, api, model_name, operation: fr.Float(example=val.default),
+    ma.Pluck: lambda val, api, model_name, operation: fr.Raw(example=val.default),
+    ma.Raw: lambda val, api, model_name, operation: fr.Raw(example=val.default),
+    ma.Str: lambda val, api, model_name, operation: fr.String(example=val.default),
+    ma.String: lambda val, api, model_name, operation: fr.String(example=val.default),
+    ma.Time: lambda val, api, model_name, operation: fr.DateTime(example=val.default),
+    ma.Url: lambda val, api, model_name, operation: fr.Url(example=val.default),
+    ma.URL: lambda val, api, model_name, operation: fr.Url(example=val.default),
+    ma.UUID: lambda val, api, model_name, operation: fr.String(example=val.default),
     ma.List: unpack_list,
     ma.Nested: unpack_nested,
     Schema: for_swagger,
@@ -104,5 +126,5 @@ def get_default_model_name(schema: Optional[Union[Schema, Type[Schema]]] = None)
     return name
 
 
-def map_type(val, api, model_name):
-    return type_map[type(val)](val, api, model_name)
+def map_type(val, api, model_name, operation):
+    return type_map[type(val)](val, api, model_name, operation)

--- a/flask_accepts/utils_test.py
+++ b/flask_accepts/utils_test.py
@@ -44,6 +44,36 @@ def test_unpack_nested():
     assert result
 
 
+def test_unpack_nested_self():
+    app = Flask(__name__)
+    api = Api(app)
+
+    class IntegerSchema(Schema):
+        my_int = ma.Integer()
+        children = ma.Nested("self", exclude=["children"])
+
+    schema = IntegerSchema()
+
+    result = utils.unpack_nested(schema.fields.get("children"), api=api)
+
+    assert type(result) == fr.Nested
+
+
+def test_unpack_nested_self_many():
+    app = Flask(__name__)
+    api = Api(app)
+
+    class IntegerSchema(Schema):
+        my_int = ma.Integer()
+        children = ma.Nested("self", exclude=["children"], many=True)
+
+    schema = IntegerSchema()
+
+    result = utils.unpack_nested(schema.fields.get("children"), api=api)
+
+    assert type(result) == fr.List
+
+
 def test_get_default_model_name():
     from .utils import get_default_model_name
 


### PR DESCRIPTION
Swagger doc not working with Marshmallow schemas nested within themselves like this:

```python
class SignalSchema(Schema):
    """Signal Schema"""

    signalId = fields.Number(attribute="id")
    signalFull = fields.String(attribute="signal")
    children = fields.Nested("self", many=True, exclude=["children"], dump_only=True)
```
Example from Marshmallow docs [here.](https://marshmallow.readthedocs.io/en/latest/nesting.html#nesting-a-schema-within-itself) 

This causes the following error:
```
File "/site-packages/flask_accepts/decorators/decorators.py", line 207, in decorator
    schema=schema, model_name=model_name, api=api, operation="dump"
File "/site-packages/flask_accepts/utils.py", line 39, in for_swagger
    for k, v in (vars(schema).get("fields").items())
File "/site-packages/flask_accepts/utils.py", line 40, in <dictcomp>
    if type(v) in type_map and _check_load_dump_only(v, operation)
File "/site-packages/flask_accepts/utils.py", line 108, in map_type
    return type_map[type(val)](val, api, model_name)
File "/site-packages/flask_accepts/utils.py", line 14, in unpack_nested
    model_name = get_default_model_name(val.nested)
File "/site-packages/flask_accepts/utils.py", line 99, in get_default_model_name
    return "".join(schema.__name__.rsplit("Schema", 1))
AttributeError: 'str' object has no attribute '__name__'
```

These commits removes this error and makes it possible to create swagger doc when schemas are nested in this way.

