### PR TITLE
Issue #36. Added 'required', 'default' and 'description' fields to result Swagger docs

### DIFF
--- a/flask_accepts/utils.py
+++ b/flask_accepts/utils.py
@@ -7,7 +7,9 @@ import uuid
 
 def unpack_list(val, api, model_name: str = None, operation: str = "dump"):
     model_name = model_name or get_default_model_name()
-    return fr.List(map_type(val.inner, api, model_name, operation))
+    return fr.List(
+        map_type(val.inner, api, model_name, operation), **_ma_field_to_fr_field(val)
+    )
 
 
 def unpack_nested(val, api, model_name: str = None, operation: str = "dump"):
@@ -15,7 +17,9 @@ def unpack_nested(val, api, model_name: str = None, operation: str = "dump"):
         return unpack_nested_self(val, api, model_name, operation)
 
     model_name = get_default_model_name(val.nested)
-    return fr.Nested(map_type(val.nested, api, model_name, operation))
+    return fr.Nested(
+        map_type(val.nested, api, model_name, operation), **_ma_field_to_fr_field(val)
+    )
 
 
 def unpack_nested_self(val, api, model_name: str = None, operation: str = "dump"):
@@ -26,9 +30,13 @@ def unpack_nested_self(val, api, model_name: str = None, operation: str = "dump"
         if type(v) in type_map and _check_load_dump_only(v, operation)
     }
     if val.many:
-        return fr.List(fr.Nested(api.model(f"{model_name}-child", fields)))
+        return fr.List(
+            fr.Nested(api.model(f"{model_name}-child", fields), **_ma_field_to_fr_field(val))
+        )
     else:
-        return fr.Nested(api.model(f"{model_name}-child", fields))
+        return fr.Nested(
+            api.model(f"{model_name}-child", fields), **_ma_field_to_fr_field(val)
+        )
 
 
 def for_swagger(schema, api, model_name: str = None, operation: str = "dump"):
@@ -72,37 +80,81 @@ def _check_load_dump_only(field: ma.Field, operation: str) -> bool:
 
 type_map = {
     ma.AwareDateTime: lambda val, api, model_name, operation: fr.Raw(
-        example=val.default
+        **_ma_field_to_fr_field(val)
     ),
-    ma.Bool: lambda val, api, model_name, operation: fr.Boolean(example=val.default),
-    ma.Boolean: lambda val, api, model_name, operation: fr.Boolean(example=val.default),
-    ma.Constant: lambda val, api, model_name, operation: fr.Raw(example=val.default),
-    ma.Date: lambda val, api, model_name, operation: fr.Date(example=val.default),
+    ma.Bool: lambda val, api, model_name, operation: fr.Boolean(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Boolean: lambda val, api, model_name, operation: fr.Boolean(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Constant: lambda val, api, model_name, operation: fr.Raw(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Date: lambda val, api, model_name, operation: fr.Date(
+        **_ma_field_to_fr_field(val)
+    ),
     ma.DateTime: lambda val, api, model_name, operation: fr.DateTime(
-        example=val.default
+        **_ma_field_to_fr_field(val)
     ),
     # For some reason, fr.Decimal has no example parameter, so use Float instead
-    ma.Decimal: lambda val, api, model_name, operation: fr.Float(example=val.default),
-    ma.Dict: lambda val, api, model_name, operation: fr.Raw(example=val.default),
-    ma.Email: lambda val, api, model_name, operation: fr.String(example=val.default),
-    ma.Float: lambda val, api, model_name, operation: fr.Float(example=val.default),
-    ma.Function: lambda val, api, model_name, operation: fr.Raw(example=val.default),
-    ma.Int: lambda val, api, model_name, operation: fr.Integer(example=val.default),
-    ma.Integer: lambda val, api, model_name, operation: fr.Integer(example=val.default),
-    ma.Length: lambda val, api, model_name, operation: fr.Float(example=val.default),
-    ma.Mapping: lambda val, api, model_name, operation: fr.Raw(example=val.default),
-    ma.NaiveDateTime: lambda val, api, model_name, operation: fr.DateTime(
-        example=val.default
+    ma.Decimal: lambda val, api, model_name, operation: fr.Float(
+        **_ma_field_to_fr_field(val)
     ),
-    ma.Number: lambda val, api, model_name, operation: fr.Float(example=val.default),
-    ma.Pluck: lambda val, api, model_name, operation: fr.Raw(example=val.default),
-    ma.Raw: lambda val, api, model_name, operation: fr.Raw(example=val.default),
-    ma.Str: lambda val, api, model_name, operation: fr.String(example=val.default),
-    ma.String: lambda val, api, model_name, operation: fr.String(example=val.default),
-    ma.Time: lambda val, api, model_name, operation: fr.DateTime(example=val.default),
-    ma.Url: lambda val, api, model_name, operation: fr.Url(example=val.default),
-    ma.URL: lambda val, api, model_name, operation: fr.Url(example=val.default),
-    ma.UUID: lambda val, api, model_name, operation: fr.String(example=val.default),
+    ma.Dict: lambda val, api, model_name, operation: fr.Raw(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Email: lambda val, api, model_name, operation: fr.String(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Float: lambda val, api, model_name, operation: fr.Float(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Function: lambda val, api, model_name, operation: fr.Raw(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Int: lambda val, api, model_name, operation: fr.Integer(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Integer: lambda val, api, model_name, operation: fr.Integer(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Length: lambda val, api, model_name, operation: fr.Float(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Mapping: lambda val, api, model_name, operation: fr.Raw(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.NaiveDateTime: lambda val, api, model_name, operation: fr.DateTime(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Number: lambda val, api, model_name, operation: fr.Float(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Pluck: lambda val, api, model_name, operation: fr.Raw(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Raw: lambda val, api, model_name, operation: fr.Raw(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Str: lambda val, api, model_name, operation: fr.String(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.String: lambda val, api, model_name, operation: fr.String(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Time: lambda val, api, model_name, operation: fr.DateTime(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.Url: lambda val, api, model_name, operation: fr.Url(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.URL: lambda val, api, model_name, operation: fr.Url(
+        **_ma_field_to_fr_field(val)
+    ),
+    ma.UUID: lambda val, api, model_name, operation: fr.String(
+        **_ma_field_to_fr_field(val)
+    ),
     ma.List: unpack_list,
     ma.Nested: unpack_nested,
     Schema: for_swagger,
@@ -124,6 +176,24 @@ def get_default_model_name(schema: Optional[Union[Schema, Type[Schema]]] = None)
     name = f"DefaultResponseModel_{num_default_models}"
     num_default_models += 1
     return name
+
+
+def _ma_field_to_fr_field(value: ma.Field) -> dict:
+    fr_field_parameters = {}
+
+    if hasattr(value, 'default'):
+        fr_field_parameters['example'] = value.default
+
+    if hasattr(value, 'required'):
+        fr_field_parameters['required'] = value.required
+
+    if hasattr(value, 'metadata') and 'description' in value.metadata:
+        fr_field_parameters['description'] = value.metadata['description']
+
+    if hasattr(value, 'missing') and type(value.missing) != ma.utils._Missing:
+        fr_field_parameters['default'] = value.missing
+
+    return fr_field_parameters
 
 
 def map_type(val, api, model_name, operation):

--- a/flask_accepts/utils_test.py
+++ b/flask_accepts/utils_test.py
@@ -158,3 +158,88 @@ def test__check_load_dump_only_raises_on_invalid_operation():
             FakeField(load_only=True, dump_only=False), "not an operation"
         )
 
+
+def test__ma_field_to_fr_field_converts_required_param_if_present():
+    @dataclass
+    class FakeFieldWithRequired(ma.Field):
+        required: bool
+
+    fr_field_dict = utils._ma_field_to_fr_field(FakeFieldWithRequired(required=True))
+    assert fr_field_dict['required'] is True
+
+    @dataclass
+    class FakeFieldNoRequired(ma.Field):
+        pass
+
+    fr_field_dict = utils._ma_field_to_fr_field(FakeFieldNoRequired())
+    assert 'required' not in fr_field_dict
+
+
+def test__ma_field_to_fr_field_converts_missing_param_to_default_if_present():
+    @dataclass
+    class FakeFieldWithMissing(ma.Field):
+        missing: bool
+
+    fr_field_dict = utils._ma_field_to_fr_field(FakeFieldWithMissing(missing=True))
+    assert fr_field_dict['default'] is True
+
+    @dataclass
+    class FakeFieldNoMissing(ma.Field):
+        pass
+
+    fr_field_dict = utils._ma_field_to_fr_field(FakeFieldNoMissing())
+    assert 'default' not in fr_field_dict
+
+
+def test__ma_field_to_fr_field_converts_metadata_param_to_description_if_present():
+    @dataclass
+    class FakeFieldWithDescription(ma.Field):
+        metadata: dict
+
+    expected_description = 'test'
+
+    fr_field_dict = utils._ma_field_to_fr_field(
+        FakeFieldWithDescription(metadata={'description': expected_description})
+    )
+    assert fr_field_dict['description'] == expected_description
+
+    @dataclass
+    class FakeFieldNoMetaData(ma.Field):
+        pass
+
+    fr_field_dict = utils._ma_field_to_fr_field(FakeFieldNoMetaData())
+    assert 'description' not in fr_field_dict
+
+    @dataclass
+    class FakeFieldNoDescription(ma.Field):
+        metadata: dict
+
+    fr_field_dict = utils._ma_field_to_fr_field(FakeFieldNoDescription(metadata={}))
+    assert 'description' not in fr_field_dict
+
+
+def test__ma_field_to_fr_field_converts_default_to_example_if_present():
+    @dataclass
+    class FakeFieldWithDefault(ma.Field):
+        default: str
+
+    expected_example_value = 'test'
+
+    fr_field_dict = utils._ma_field_to_fr_field(FakeFieldWithDefault(default=expected_example_value))
+    assert fr_field_dict['example'] == expected_example_value
+
+    @dataclass
+    class FakeFieldNoDefault(ma.Field):
+        pass
+
+    fr_field_dict = utils._ma_field_to_fr_field(FakeFieldNoDefault())
+    assert 'example' not in fr_field_dict
+
+
+def test__ma_field_to_fr_field_returns_empty_dict_for_no_params_present_in_ma_field():
+    @dataclass
+    class FakeFieldWithNoParams(ma.Field):
+        pass
+
+    fr_field_dict = utils._ma_field_to_fr_field(FakeFieldWithNoParams())
+    assert not fr_field_dict


### PR DESCRIPTION
Resolves Issue #36 
Was thinking about ways to get rid of same function call for every type.

Thought of functional programming approach, but decided to leave it like that for now. Mainly, because of last 4 types in the dictionary (ma.List, ma.Nested, Schema and SchemaMeta). They messed up all ideas I was thinking about. Like using mapping function over dictionary with types map.

Any ideas on how code quality can be improved in this context?