### PR TITLE
Only append the operation to model name if necessary; Fixes #35

### DIFF
--- a/flask_accepts/utils.py
+++ b/flask_accepts/utils.py
@@ -56,7 +56,14 @@ def for_swagger(schema, api, model_name: str = None, operation: str = "dump"):
         if type(v) in type_map and _check_load_dump_only(v, operation)
     }
 
-    return api.model(f"{model_name}-{operation}", fields)
+    model_name = _maybe_add_operation(schema, model_name, operation)
+    return api.model(model_name, fields)
+
+
+def _maybe_add_operation(schema, model_name: str, operation: str):
+    if any(f.load_only or f.dump_only for k, f in (vars(schema).get("fields").items())):
+        return f"{model_name}-{operation}"
+    return f"{model_name}"
 
 
 def _check_load_dump_only(field: ma.Field, operation: str) -> bool:

--- a/flask_accepts/utils_test.py
+++ b/flask_accepts/utils_test.py
@@ -158,3 +158,63 @@ def test__check_load_dump_only_raises_on_invalid_operation():
             FakeField(load_only=True, dump_only=False), "not an operation"
         )
 
+
+def test__maybe_add_operation_passes_through_if_no_load_only():
+    from flask_accepts.utils import _maybe_add_operation
+
+    class TestSchema(Schema):
+        _id = ma.Integer()
+
+    model_name = "TestSchema"
+    operation = "load"
+
+    result = _maybe_add_operation(TestSchema(), model_name, operation)
+
+    expected = model_name
+    assert result == expected
+
+
+def test__maybe_add_operation_append_if_load_only():
+    from flask_accepts.utils import _maybe_add_operation
+
+    class TestSchema(Schema):
+        _id = ma.Integer(load_only=True)
+
+    model_name = "TestSchema"
+    operation = "load"
+
+    result = _maybe_add_operation(TestSchema(), model_name, operation)
+
+    expected = f"{model_name}-load"
+    assert result == expected
+
+
+def test__maybe_add_operation_passes_through_if_no_dump_only():
+    from flask_accepts.utils import _maybe_add_operation
+
+    class TestSchema(Schema):
+        _id = ma.Integer()
+
+    model_name = "TestSchema"
+    operation = "dump"
+
+    result = _maybe_add_operation(TestSchema(), model_name, operation)
+
+    expected = model_name
+    assert result == expected
+
+
+def test__maybe_add_operation_append_if_dump_only():
+    from flask_accepts.utils import _maybe_add_operation
+
+    class TestSchema(Schema):
+        _id = ma.Integer(dump_only=True)
+
+    model_name = "TestSchema"
+    operation = "dump"
+
+    result = _maybe_add_operation(TestSchema(), model_name, operation)
+
+    expected = f"{model_name}-dump"
+    assert result == expected
+


### PR DESCRIPTION
This modification introspects the schema and only appends the `-load` or `-dump` suffixes (which are necessary to keep some record that there are models with `load_only` and/or `dump_only` underlying based upon the provided schemas, and only adds the suffix if the Schema actually uses those fields. The result is that for the case where `load_only` and `dump_only` are NOT provided, the model names are prettier