### PR TITLE
Issue #39 resolved. Added support for ma schema instances as nested field in outer schema

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -90,3 +90,7 @@
   0.14.1
 
 - Add 'required', 'default' and 'description' fields to result Swagger docs
+
+  0.14.2
+
+- Add support for schema instances in marshmallow nested fields. 

--- a/flask_accepts/utils.py
+++ b/flask_accepts/utils.py
@@ -175,4 +175,12 @@ def _ma_field_to_fr_field(value: ma.Field) -> dict:
 
 
 def map_type(val, api, model_name, operation):
-    return type_map[type(val)](val, api, model_name, operation)
+    value_type = type(val)
+
+    if value_type in type_map:
+        return type_map[value_type](val, api, model_name, operation)
+
+    if isinstance(value_type, SchemaMeta) or isinstance(value_type, Schema):
+        return type_map[Schema](val, api, model_name, operation)
+
+    raise TypeError('Unknown type for marshmallow model field was used.')

--- a/flask_accepts/utils_test.py
+++ b/flask_accepts/utils_test.py
@@ -1,9 +1,11 @@
-from dataclasses import dataclass
-from unittest.mock import MagicMock, patch
 import pytest
+
+from dataclasses import dataclass
+from unittest.mock import patch, Mock
 from marshmallow import Schema, fields as ma
+
 from flask import Flask
-from flask_restplus import Resource, Api, fields as fr
+from flask_restplus import Api, fields as fr, namespace
 
 # from .utils import unpack_list, unpack_nested
 import flask_accepts.utils as utils
@@ -257,6 +259,7 @@ def test_make_type_mapper_works_with_required():
     result = mapper(ma.Raw(required=True), api=api, model_name='test_model_name', operation='load')
     assert result.required
 
+
 def test_make_type_mapper_produces_nonrequired_param_by_default():
     from flask_accepts.utils import make_type_mapper
 
@@ -327,3 +330,55 @@ def test__maybe_add_operation_append_if_dump_only():
     expected = f"{model_name}-dump"
     assert result == expected
 
+
+def test_map_type_calls_type_map_dict_function_for_known_type_with_correct_parameters():
+    expected_ma_field = ma.Float
+    expected_model_name, expected_operation, expected_namespace = _get_type_mapper_default_params()
+
+    float_type_mapper = Mock()
+    type_map_mock = {
+        type(expected_ma_field): float_type_mapper
+    }
+
+    type_map_patch = patch.object(utils, 'type_map', new=type_map_mock)
+
+    with type_map_patch:
+        utils.map_type(expected_ma_field, expected_namespace, expected_model_name, expected_operation)
+        float_type_mapper.assert_called_with(
+            expected_ma_field, expected_namespace, expected_model_name, expected_operation
+        )
+
+
+def test_map_type_calls_type_map_dict_function_for_schema_instance():
+    class MarshmallowSchema(Schema):
+        test_field: ma.Float
+
+    expected_ma_field = MarshmallowSchema()
+    expected_model_name, expected_operation, expected_namespace = _get_type_mapper_default_params()
+
+    schema_type_mapper_mock = Mock()
+    type_map_mock = dict(utils.type_map)
+    type_map_mock[Schema] = schema_type_mapper_mock
+
+    type_map_patch = patch.object(utils, 'type_map', new=type_map_mock)
+
+    with type_map_patch:
+        utils.map_type(expected_ma_field, expected_namespace, expected_model_name, expected_operation)
+        schema_type_mapper_mock.assert_called_with(
+            expected_ma_field, expected_namespace, expected_model_name, expected_operation
+        )
+
+
+def test_map_type_raises_error_for_unknown_type():
+    class UnknownType:
+        test_field: ma.Float
+
+    unknown_ma_field = UnknownType
+    expected_model_name, expected_operation, expected_namespace = _get_type_mapper_default_params()
+
+    with pytest.raises(TypeError):
+        utils.map_type(unknown_ma_field, expected_namespace, expected_model_name, expected_operation)
+
+
+def _get_type_mapper_default_params():
+    return 'test-model', 'test-operation', namespace.Namespace('test-ns')


### PR DESCRIPTION
Resolves #39 
Adds possibility to use marshmallow schema instance as first parameter of Nested fields constructor.