### PR TITLE
Use the ignored validate arg for enforcing schema in @responds

### DIFF
--- a/flask_accepts/decorators/decorators_test.py
+++ b/flask_accepts/decorators/decorators_test.py
@@ -493,3 +493,22 @@ def test_accepts_with_twice_nested_schema(app, client):  # noqa
         )
         assert resp.status_code == 200
 
+def test_responds_with_validate(app, client):  # noqa
+    class TestSchema(Schema):
+        _id = fields.Integer(required=True)
+        name = fields.String(required=True)
+
+    api = Api(app)
+
+    @api.route("/test")
+    class TestResource(Resource):
+        @responds(schema=TestSchema, api=api, validate=True)
+        def get(self):
+            obj = {"wrong_field": 42, "name": "Jon Snow"}
+            return obj
+
+    with client as cl:
+        resp = cl.get("/test")
+        obj = resp.json
+        assert resp.status_code == 500
+        assert resp.json == {'message': 'Server attempted to return invalid data'}


### PR DESCRIPTION
Although https://github.com/apryor6/flask_accepts/issues/42 was closed I'd like to start a discussion about at least having the possibility of enforcing the schema in `@responds`

There was a previously unused `validate` param could fit this usecase.

IMHO this is a very important feature for ensuring implementation follows the Swagger doc contract (as others point out over at https://github.com/noirbizarre/flask-restplus/issues/478)