### PR TITLE
add marshmallow support for @responds when validate is True

### DIFF
--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -190,14 +190,15 @@ def responds(
             if isinstance(rv, Response):
                 return rv
             if schema:
+                serialized = schema.dump(rv)
+
                 # Validate data if asked to (throws)
                 if validate:
-                    errs = schema.validate(rv)
+                    errs = schema.validate(serialized)
                     if errs:
                         raise InternalServerError(
                             description='Server attempted to return invalid data'
                         )
-                serialized = schema.dump(rv)
             else:
                 from flask_restplus import marshal
 


### PR DESCRIPTION
https://github.com/apryor6/flask_accepts/pull/44
The implementation of validate=True does not work when returned object is not dict.
@elnygren you use schema.validate(rv) (line 193), but this method should be used before deserializing rather then serializing. schema.validate expects Mapping object.
https://marshmallow.readthedocs.io/en/stable/quickstart.html#

So, changes in code should be as following:
data = schema.dump(object_to_serialize)
schema.validate(data)