### PR TITLE
Adds handling for query string schema

### DIFF
--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -2,18 +2,21 @@ from typing import Type, Union
 from flask import jsonify
 from werkzeug.wrappers import Response
 from werkzeug.exceptions import BadRequest, InternalServerError
-from marshmallow import Schema
+from marshmallow import Schema, EXCLUDE, RAISE
+from marshmallow.fields import List
 from marshmallow.exceptions import ValidationError
 
 from flask_restx.model import Model
 from flask_restx import fields, reqparse, inputs
-from flask_accepts.utils import for_swagger, get_default_model_name
+from flask_accepts.utils import for_swagger, get_default_model_name, is_list_field, ma_field_to_reqparse_argument
 
 
 def accepts(
     *args,
     model_name: str = None,
     schema: Union[Schema, Type[Schema], None] = None,
+    query_params_schema: Union[Schema, Type[Schema], None] = None,
+    headers_schema: Union[Schema, Type[Schema], None] = None,
     many: bool = False,
     api=None,
     use_swagger: bool = True,
@@ -26,15 +29,20 @@ def accepts(
         *args: any number of dictionaries containing parameters to pass to
             reqparse.RequestParser().add_argument(). A single string parameter may also be
             provided that is used as the model name.  By default these parameters
-            will be parsed using the default logic
-            however, if a schema is provided then the JSON body is assumed to correspond
-            to it and will not be parsed for query params
+            will be parsed using the default logic however, if a schema is provided then
+            the JSON body is assumed to correspond to it and will not be parsed for query params.
         model_name (str): the name to pass to api.Model, can optionally be provided as a str argument to *args
         schema (Marshmallow.Schema, optional): A Marshmallow Schema that will be used to parse JSON
-            data from the request body and
-            store in request.parsed_bj. Defaults to None.
+            data from the request body and store in request.parsed_obj. Defaults to None.
+        query_params_schema (Marshmallow.Schema, optional): A Marshmallow Schema that will be used to parse
+            data from the request query params and store in request.parsed_query_params. These values will
+            also be added to the `request.args` dict. Defaults to None.
+        headers_schema (Marshmallow.Schema, optional): A Marshmallow Schema that will be used to parse
+            data from the request header and store in request.parsed_headers. Defaults to None.
         many (bool, optional): The Marshmallow schema `many` parameter, which will
-            return a list of the corresponding schema objects when set to True.
+            return a list of the corresponding schema objects when set to True. This
+            flag corresopnds only to the request body schema, and not the
+            `query_params_schema` or `headers_schema` arguments.
 
     Returns:
         The wrapped route
@@ -54,6 +62,8 @@ def accepts(
         if isinstance(arg, str):
             model_name = arg
             break
+
+    # Handles query params passed in as positional arguments.
     for qp in query_params:
         params = {**qp, "location": qp.get("location") or "values"}
         if qp["type"] == bool:
@@ -62,8 +72,25 @@ def accepts(
             params["type"] = inputs.boolean
         _parser.add_argument(**params)
 
+    # Handles request body schema.
     if schema:
         schema = _get_or_create_schema(schema, many=many)
+
+    # Handles query params schema.
+    if query_params_schema:
+        query_params_schema = _get_or_create_schema(query_params_schema, unknown=EXCLUDE)
+
+        for name, field in query_params_schema.fields.items():
+            params = {**ma_field_to_reqparse_argument(field), "location": "values"}
+            _parser.add_argument(name, **params)
+
+    # Handles headers schema.
+    if headers_schema:
+        headers_schema = _get_or_create_schema(headers_schema, unknown=EXCLUDE)
+
+        for name, field in headers_schema.fields.items():
+            params = {**ma_field_to_reqparse_argument(field), "location": "headers"}
+            _parser.add_argument(name, **params)
 
     def decorator(func):
         from functools import wraps
@@ -76,13 +103,14 @@ def accepts(
             from flask import request
 
             error = schema_error = None
+
             # Handle arguments
             try:
                 request.parsed_args = _parser.parse_args()
             except Exception as e:
                 error = e
 
-            # Handle Marshmallow schema
+            # Handle Marshmallow schema for request body
             if schema:
                 try:
                     obj = schema.load(request.get_json())
@@ -91,7 +119,47 @@ def accepts(
                     schema_error = ex.messages
                 if schema_error:
                     error = error or BadRequest(
-                        f"Invalid parsing error: {schema_error}"
+                        f"Error parsing request body: {schema_error}"
+                    )
+                    if hasattr(error, "data"):
+                        error.data["errors"].update({"schema_errors": schema_error})
+                    else:
+                        error.data = {"schema_errors": schema_error}
+
+            # Handle Marshmallow schema for query params
+            if query_params_schema:
+                request_args = _convert_multidict_values_to_schema(
+                    request.args,
+                    query_params_schema)
+
+                try:
+                    obj = query_params_schema.load(request_args)
+                    request.parsed_query_params = obj
+                except ValidationError as ex:
+                    schema_error = ex.messages
+                if schema_error:
+                    error = error or BadRequest(
+                        f"Error parsing query params: {schema_error}"
+                    )
+                    if hasattr(error, "data"):
+                        error.data["errors"].update({"schema_errors": schema_error})
+                    else:
+                        error.data = {"schema_errors": schema_error}
+
+            # Handle Marshmallow schema for headers
+            if headers_schema:
+                request_headers = _convert_multidict_values_to_schema(
+                    request.headers,
+                    headers_schema)
+
+                try:
+                    obj = headers_schema.load(request_headers)
+                    request.parsed_headers = obj
+                except ValidationError as ex:
+                    schema_error = ex.messages
+                if schema_error:
+                    error = error or BadRequest(
+                        f"Error parsing headers: {schema_error}"
                     )
                     if hasattr(error, "data"):
                         error.data["errors"].update({"schema_errors": schema_error})
@@ -261,11 +329,11 @@ def _check_deprecate_many(many: bool = False):
 
 
 def _get_or_create_schema(
-    schema: Union[Schema, Type[Schema]], many: bool = False
+    schema: Union[Schema, Type[Schema]], many: bool = False, unknown: str = RAISE
 ) -> Schema:
     if isinstance(schema, Schema):
         return schema
-    return schema(many=many)
+    return schema(many=many, unknown=unknown)
 
 
 def _model_from_parser(model_name: str, parser: reqparse.RequestParser) -> Model:
@@ -314,3 +382,38 @@ def _is_method(func):
 
     sig = inspect.signature(func)
     return "self" in sig.parameters
+
+
+def _convert_multidict_values_to_schema(multidict, schema):
+    """Helper function that converts values in the given multidict into either
+    single or list values based on the schema definition.
+
+    This function is necessary for parsing multidict mappings like querystrings
+    where it's ambiguous whether the value is single or list value. Take the
+    following query string as an example:
+
+        ?foo=bar
+
+    In this case, `foo` could map to a single string `'bar'`, or a list with
+    one string element `['bar']`.
+
+    This function looks at the given `schema` and converts the values in the
+    given `multidict` appropriately to be parsed be loaded by `marshmallow`
+    later on.
+    """
+    result = {}
+
+    fields = dict(schema.fields.items())
+    for key, value in multidict.items():
+        # If the key isn't defined in the schema, then insert it into the
+        # result set as is and let marshmallow validation raise an error.
+        if key not in fields:
+            result[key] = value
+        # If the corresponding field is a list, then make sure to return the
+        # value as a list.
+        elif is_list_field(fields[key]):
+            result[key] = multidict.getlist(key)
+        else:
+            result[key] = value
+
+    return result

--- a/flask_accepts/utils_test.py
+++ b/flask_accepts/utils_test.py
@@ -257,7 +257,7 @@ def test_make_type_mapper_works_with_required():
     api = Api(app)
 
     mapper = make_type_mapper(fr.Raw)
-    result = mapper(ma.Raw(required=True), api=api, model_name='test_model_name', operation='load')
+    result = mapper(ma.Raw(required=True), api=api, model_name="test_model_name", operation="load")
     assert result.required
 
 
@@ -268,7 +268,7 @@ def test_make_type_mapper_produces_nonrequired_param_by_default():
     api = Api(app)
 
     mapper = make_type_mapper(fr.Raw)
-    result = mapper(ma.Raw(), api=api, model_name='test_model_name', operation='load')
+    result = mapper(ma.Raw(), api=api, model_name="test_model_name", operation="load")
     assert not result.required
 
 
@@ -341,7 +341,7 @@ def test_map_type_calls_type_map_dict_function_for_known_type_with_correct_param
         type(expected_ma_field): float_type_mapper
     }
 
-    type_map_patch = patch.object(utils, 'type_map', new=type_map_mock)
+    type_map_patch = patch.object(utils, "type_map", new=type_map_mock)
 
     with type_map_patch:
         utils.map_type(expected_ma_field, expected_namespace, expected_model_name, expected_operation)
@@ -361,7 +361,7 @@ def test_map_type_calls_type_map_dict_function_for_schema_instance():
     type_map_mock = dict(utils.type_map)
     type_map_mock[Schema] = schema_type_mapper_mock
 
-    type_map_patch = patch.object(utils, 'type_map', new=type_map_mock)
+    type_map_patch = patch.object(utils, "type_map", new=type_map_mock)
 
     with type_map_patch:
         utils.map_type(expected_ma_field, expected_namespace, expected_model_name, expected_operation)
@@ -384,7 +384,7 @@ def test_map_type_calls_type_map_dict_function_for_schema_class():
     type_map_mock = dict(utils.type_map)
     type_map_mock[Schema] = schema_type_mapper_mock
 
-    type_map_patch = patch.object(utils, 'type_map', new=type_map_mock)
+    type_map_patch = patch.object(utils, "type_map", new=type_map_mock)
 
     with type_map_patch:
         utils.map_type(expected_ma_field, expected_namespace, expected_model_name, expected_operation)
@@ -405,4 +405,33 @@ def test_map_type_raises_error_for_unknown_type():
 
 
 def _get_type_mapper_default_params():
-    return 'test-model', 'test-operation', namespace.Namespace('test-ns')
+    return "test-model", "test-operation", namespace.Namespace("test-ns")
+
+
+def test_ma_field_to_reqparse_argument_single_values():
+    # Test a simple integer.
+    result = utils.ma_field_to_reqparse_argument(ma.Integer(required=True))
+    assert result["type"] is int
+    assert result["required"] is True
+    assert result["action"] == "store"
+    assert "help" not in result
+
+    # Test that complex fields default to string.
+    result = utils.ma_field_to_reqparse_argument(ma.Email(required=True, description="A description"))
+    assert result["type"] is str
+    assert result["required"] is True
+    assert result["action"] == "store"
+    assert result["help"] == "A description"
+
+def test_ma_field_to_reqparse_argument_list_values():
+    result = utils.ma_field_to_reqparse_argument(ma.List(ma.Integer()))
+    assert result["type"] is int
+    assert result["required"] is False
+    assert result["action"] == "append"
+    assert "help" not in result
+
+    result = utils.ma_field_to_reqparse_argument(ma.List(ma.String(), description="A description"))
+    assert result["type"] is str
+    assert result["required"] is False
+    assert result["action"] == "append"
+    assert result["help"] == "A description"


### PR DESCRIPTION
@apryor6 This is a first draft at addressing issues #45 and #67. Per your instructions, I've added two new arguments, `query_params_schema` and `headers_schema`, which allow users to pass in marshmallow schemas for parsing query params and header values.

The current behavior is as follows:

- Query params that get parsed and stored in `request.parsed_query_params`. Unknown values are excluded.
- Headers get parsed and stored in `request.parsed_headers`. Unknown values are excluded.
- All query param and header fields get added to the `reqparse.RequestParser`, which allows those fields to show up in the swagger docs. Unfortunately this also means that query param and header fields will show up in `request.parsed_args`, which could be confusing. If there's a better way to get the query params and headers to show up in the swagger docs, I'd be happy to update this.

Please treat this as as first pass as I'm not married to any of the implementation details — if there are better ways to implement any of this, then let me know. Once we're at a good place with the implementation, I can help update the documentation as well.