### PR TITLE
Apply Swagger description when schema not provided

### DIFF
--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -303,7 +303,7 @@ def responds(
             elif _parser:
                 api.add_model(model_name, model_from_parser)
                 inner = _document_like_marshal_with(
-                    model_from_parser, status_code=status_code
+                    model_from_parser, status_code=status_code, description=description
                 )(inner)
 
         return inner


### PR DESCRIPTION
Currently, a custom Swagger description can only be applied when a schema is provided in the `responds` decorator. This PR makes a change to still pass `description` into `_document_like_marshal_with` when no schema is found.