### PR TITLE
[Swagger] Support multiple status codes in Swagger documentation

### DIFF
--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -367,7 +367,14 @@ def _model_from_parser(model_name: str, parser: reqparse.RequestParser) -> Model
 
 
 def merge(first: dict, second: dict) -> dict:
-    return {**first, **second}
+    for key, value in first.items():
+        if isinstance(value, dict):
+            node = second.setdefault(key, {})
+            merge(value, node)
+        else:
+            second[key] = value
+
+    return second
 
 
 def _document_like_marshal_with(


### PR DESCRIPTION
This change adds support for providing multiple status code responses in the generated Swagger docs. Currently, any response provided in the `@responds` decorator will completely override any additional documentation. It would be nice if any existing docs were respected and persisted. This is helpful when documenting any known errors that a route may raise, such as 404 and 401, which might not require a schema or any additional information. If desired, these responses may be added to the Swagger docs using a decorator such as `@api.doc(responses={401: "Not Authorized", 404: "Not Found"})`.

This is partially related to issue https://github.com/apryor6/flask_accepts/issues/17, however it only adds support for multiple status code responses in the Swagger docs, it does not provide any additional support for the actual response. I might look into a fix for the given issue, which would actually support multiple responses and schemas.