### PR TITLE
Option to skip response fields where value is None

### DIFF
--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -207,6 +207,7 @@ def responds(
     validate: bool = False,
     description: str = None,
     use_swagger: bool = True,
+    skip_none: bool = False,
 ):
     """
     Serialize the output of a function using the Marshmallow schema to dump the results.
@@ -284,6 +285,21 @@ def responds(
 
             if envelope:
                 serialized = OrderedDict([(envelope, serialized)]) if ordered else {envelope: serialized}
+
+            if skip_none:
+                def remove_none(obj):
+                    if isinstance(obj, list):
+                        return [remove_none(entry) for entry in obj if entry is not None]
+                    if isinstance(obj, dict):
+                        result = {}
+                        for key, value in obj.items():
+                            value = remove_none(value)
+                            if key is not None and value is not None:
+                                result[key] = value
+                        return result
+                    return obj
+
+                serialized = remove_none(serialized)
 
             if not _is_method(func):
                 # Regular route, need to manually create Response


### PR DESCRIPTION
Resolves issue https://github.com/apryor6/flask_accepts/issues/99.

## Why
It would be nice if there was a way to filter out any fields where the return value is `None`. For some responses, if a value is not present then it is better to not return the field all together rather than return a JSON `null`. Flask-RESTX provides this functionality in their `marshal_with` decorator, which allows a `skip_none` parameter to be passed in ([docs](https://flask-restx.readthedocs.io/en/latest/marshalling.html#skip-fields-which-value-is-none)). The proposed solution for this would be to allow the `responds` decorator to similarly take a `skip_none` bool parameter (defaulting to `False`), which would filter out any `None` value fields produced in the serialized object.

## In this PR
- Adds a `skip_none` boolean parameter to the `responds` decorator
- If `skip_none` is set as `True`, then removes any fields that have a `None` value from the serialized object
- `None` removal logic implemented recursively to handle for nested schemas