### PR TITLE
Added type-checking for ma.utils._Missing for default values utils._m…

### DIFF
--- a/flask_accepts/utils.py
+++ b/flask_accepts/utils.py
@@ -160,7 +160,7 @@ def get_default_model_name(schema: Optional[Union[Schema, Type[Schema]]] = None)
 def _ma_field_to_fr_field(value: ma.Field) -> dict:
     fr_field_parameters = {}
 
-    if hasattr(value, "default"):
+    if hasattr(value, "default") and type(value.default) != ma.utils._Missing:
         fr_field_parameters["example"] = value.default
 
     if hasattr(value, "required"):


### PR DESCRIPTION
First of all, sorry for all the forking... It's my first pull request ever. But I think this should fix issue #103 . I added type checking for ma.utils._Missing. I think marshmallow changed the behaviour in case of missing default values and now also adds ma.utils_Missing if no default value is set (I guess it was None before? ). The json.dumps for the swagger-docs should now work again.