### PR TITLE
Fix error aggregation and body=None

### DIFF
--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -114,7 +114,7 @@ def accepts(
             # Handle Marshmallow schema for request body
             if schema:
                 try:
-                    obj = schema.load(request.get_json(force=True))
+                    obj = schema.load(request.get_json(force=True) or {})
                     request.parsed_obj = obj
                 except ValidationError as ex:
                     schema_error = ex.messages
@@ -123,7 +123,7 @@ def accepts(
                         f"Error parsing request body: {schema_error}"
                     )
                     if hasattr(error, "data"):
-                        error.data["errors"].update({"schema_errors": schema_error})
+                        error.data["schema_errors"].update(schema_error)
                     else:
                         error.data = {"schema_errors": schema_error}
 
@@ -143,7 +143,7 @@ def accepts(
                         f"Error parsing query params: {schema_error}"
                     )
                     if hasattr(error, "data"):
-                        error.data["errors"].update({"schema_errors": schema_error})
+                        error.data["schema_errors"].update(schema_error)
                     else:
                         error.data = {"schema_errors": schema_error}
 
@@ -163,7 +163,7 @@ def accepts(
                         f"Error parsing headers: {schema_error}"
                     )
                     if hasattr(error, "data"):
-                        error.data["errors"].update({"schema_errors": schema_error})
+                        error.data["schema_errors"].update(schema_error)
                     else:
                         error.data = {"schema_errors": schema_error}
 


### PR DESCRIPTION
Two bugs noticed (may not be real bugs).

When no body is present (i.e. `request.get_json()` returns `None`) the schema is presented `None` to load from, whereas an empty JSON body could better be interpreted as `{}`. For a body schema with no required fields this leads to better behavior.

Error aggregation doesn't seem to have been working correctly, as `error.data['errors']` never existed, and comment "If any parsing produced an error, combine them and reraise" hints this was the intended behavior.