### PR TITLE
Marshmallow schema for form data

### DIFF
--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -36,8 +36,9 @@ def accepts(
         schema (Marshmallow.Schema, optional): A Marshmallow Schema that will be used to parse JSON
             data from the request body and store in request.parsed_obj. Defaults to None.
         query_params_schema (Marshmallow.Schema, optional): A Marshmallow Schema that will be used to parse
-            data from the request query params and store in request.parsed_query_params. These values will
-            also be added to the `request.args` dict. Defaults to None.
+            data from the request query params as well as form data and store them in
+            request.parsed_query_params. These values will also be added to the `request.args` dict.
+            Defaults to None.
         headers_schema (Marshmallow.Schema, optional): A Marshmallow Schema that will be used to parse
             data from the request header and store in request.parsed_headers. Defaults to None.
         many (bool, optional): The Marshmallow schema `many` parameter, which will

--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -127,10 +127,10 @@ def accepts(
                     else:
                         error.data = {"schema_errors": schema_error}
 
-            # Handle Marshmallow schema for query params
+            # Handle Marshmallow schema for query params and form data
             if query_params_schema:
                 request_args = _convert_multidict_values_to_schema(
-                    request.args,
+                    request.values,
                     query_params_schema)
 
                 try:

--- a/flask_accepts/decorators/decorators_test.py
+++ b/flask_accepts/decorators/decorators_test.py
@@ -259,6 +259,24 @@ def test_accepts_with_query_params_schema_unknown_arguments(app, client):  # noq
         assert resp.status_code == 200
 
 
+def test_accepts_with_query_params_schema_form_data(app, client):  # noqa
+    class TestSchema(Schema):
+        foo = fields.Integer(required=True)
+
+    api = Api(app)
+
+    @api.route("/test")
+    class TestResource(Resource):
+        @accepts("TestSchema", query_params_schema=TestSchema, api=api)
+        def post(self):
+            assert request.parsed_query_params["foo"] == 3
+            return "success"
+
+    with client as cl:
+        resp = cl.post("/test", data={"foo": 3})
+        assert resp.status_code == 200
+
+
 def test_failure_when_query_params_schema_arg_is_missing(app, client):  # noqa
     class TestSchema(Schema):
         foo = fields.String(required=True)


### PR DESCRIPTION
This PR makes `query_params_schema` also act on form data as discussed in issue #109.