### PR TITLE
Add marshmallow data_key support for query params and header schemas

### DIFF
--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -83,7 +83,7 @@ def accepts(
 
         for name, field in query_params_schema.fields.items():
             params = {**ma_field_to_reqparse_argument(field), "location": "values"}
-            _parser.add_argument(name, **params)
+            _parser.add_argument(field.data_key or name, **params)
 
     # Handles headers schema.
     if headers_schema:
@@ -91,7 +91,7 @@ def accepts(
 
         for name, field in headers_schema.fields.items():
             params = {**ma_field_to_reqparse_argument(field), "location": "headers"}
-            _parser.add_argument(name, **params)
+            _parser.add_argument(field.data_key or name, **params)
 
     def decorator(func):
         from functools import wraps
@@ -436,7 +436,10 @@ def _convert_multidict_values_to_schema(multidict, schema):
     """
     result = {}
 
-    fields = dict(schema.fields.items())
+    fields = {
+        field.data_key or name: field
+        for name, field in schema.fields.items()
+    }
     for key, value in multidict.items():
         # If the key isn't defined in the schema, then insert it into the
         # result set as is and let marshmallow validation raise an error.

--- a/flask_accepts/decorators/decorators_test.py
+++ b/flask_accepts/decorators/decorators_test.py
@@ -259,6 +259,22 @@ def test_accepts_with_query_params_schema_unknown_arguments(app, client):  # noq
         assert resp.status_code == 200
 
 
+def test_accepts_with_query_params_schema_data_key(app, client):  # noqa
+    class TestSchema(Schema):
+        foo = fields.Integer(required=False, data_key="fooExternal")
+
+    @app.route("/test")
+    @accepts("TestSchema", query_params_schema=TestSchema)
+    def test():
+        assert request.parsed_args["fooExternal"] == 3
+        assert request.parsed_query_params["foo"] == 3
+        return "success"
+
+    with client as cl:
+        resp = cl.get("/test?fooExternal=3")
+        assert resp.status_code == 200
+
+
 def test_failure_when_query_params_schema_arg_is_missing(app, client):  # noqa
     class TestSchema(Schema):
         foo = fields.String(required=True)
@@ -331,6 +347,22 @@ def test_accepts_with_header_schema_unknown_arguments(app, client):  # noqa
 
     with client as cl:
         resp = cl.get("/test", headers={"Foo": "3", "Bar": "4"})
+        assert resp.status_code == 200
+
+
+def test_accepts_with_header_schema_data_key(app, client):  # noqa
+    class TestSchema(Schema):
+        Foo = fields.Integer(required=False, data_key="Foo-External")
+
+    @app.route("/test")
+    @accepts("TestSchema", headers_schema=TestSchema)
+    def test():
+        assert request.parsed_headers["Foo"] == 3
+        assert request.parsed_args["Foo-External"] == 3
+        return "success"
+
+    with client as cl:
+        resp = cl.get("/test", headers={"Foo-External": "3"})
         assert resp.status_code == 200
 
 


### PR DESCRIPTION
This PR implements support for marshmallow schema field `data_key` attribute when using the `query_params_schema` and `headers_schema` parameters, as discussed in #111.

This PR includes the proposed changes from previously closed PR #88, but also extends it to work as expected, and includes tests.