### PR TITLE
http status handling from obj to be serialized

### DIFF
--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -309,8 +309,8 @@ def responds(
                         )
                
                 if "status" in serialized:
-                    if type(serialized['status_code']) == int:
-                        status_code = serialized['status_code']
+                    if type(serialized['status']) == int:
+                        status_code = serialized['status']
                     else:
                         raise TypeError(description="Bad Http Status code")
                        

--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -308,7 +308,7 @@ def responds(
                             description="Server attempted to return invalid data"
                         )
                
-                if "status_code" in serialized:
+                if "status" in serialized:
                     if type(serialized['status_code']) == int:
                         status_code = serialized['status_code']
                     else:

--- a/flask_accepts/decorators/decorators.py
+++ b/flask_accepts/decorators/decorators.py
@@ -307,7 +307,13 @@ def responds(
                         raise InternalServerError(
                             description="Server attempted to return invalid data"
                         )
-
+               
+                if "status_code" in serialized:
+                    if type(serialized['status_code']) == int:
+                        status_code = serialized['status_code']
+                    else:
+                        raise TypeError(description="Bad Http Status code")
+                       
                 # Apply the flask-restx mask after validation
                 serialized = _apply_restx_mask(serialized)
             else:


### PR DESCRIPTION
To change the serialized response of the decorator, please add a key "status" in your obj to be serialized

`{
...
"status": int
}`

this field going to override the HTTP RESPONSE STATUS, default = 200